### PR TITLE
Downgrade platform requirement and link frameworks

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/LibFido2Swift.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/LibFido2Swift.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1600"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,12 @@ let package = Package(
         .target(
             name: "LibFido2Swift",
             dependencies: ["LibCrypto", "libfido2", "LibCbor"],
-            path: "LibFido2Swift"
+            path: "LibFido2Swift",
+            linkerSettings: [
+                .linkedLibrary("LibCbor"),
+                .linkedLibrary("LibCrypto"),
+                .linkedLibrary("libfido2"),
+            ]
         ),
         .binaryTarget(name: "LibCbor", path: "./Frameworks/LibCbor.xcframework"),
         .binaryTarget(name: "LibCrypto", path: "./Frameworks/LibCrypto.xcframework"),

--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
             dependencies: ["libCrypto", "libfido2", "libCbor"],
             path: "LibFido2Swift",
             linkerSettings: [
-                .linkedLibrary("libCbor"),
-                .linkedLibrary("libCrypto"),
-                .linkedLibrary("libfido2"),
+                .linkedFramework("libCbor"),
+                .linkedFramework("libCrypto"),
+                .linkedFramework("libfido2"),
             ]
         ),
         .binaryTarget(name: "libCbor", path: "./Frameworks/libCbor.xcframework"),

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "LibFido2Swift",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v10_15)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -17,16 +17,16 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "LibFido2Swift",
-            dependencies: ["LibCrypto", "libfido2", "LibCbor"],
+            dependencies: ["libCrypto", "libfido2", "libCbor"],
             path: "LibFido2Swift",
             linkerSettings: [
-                .linkedLibrary("LibCbor"),
-                .linkedLibrary("LibCrypto"),
+                .linkedLibrary("libCbor"),
+                .linkedLibrary("libCrypto"),
                 .linkedLibrary("libfido2"),
             ]
         ),
-        .binaryTarget(name: "LibCbor", path: "./Frameworks/LibCbor.xcframework"),
-        .binaryTarget(name: "LibCrypto", path: "./Frameworks/LibCrypto.xcframework"),
+        .binaryTarget(name: "libCbor", path: "./Frameworks/libCbor.xcframework"),
+        .binaryTarget(name: "libCrypto", path: "./Frameworks/libCrypto.xcframework"),
         .binaryTarget(name: "libfido2", path: "./Frameworks/libfido2.xcframework"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,16 +17,16 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "LibFido2Swift",
-            dependencies: ["libCrypto", "libfido2", "libCbor"],
+            dependencies: ["LibCrypto", "libfido2", "LibCbor"],
             path: "LibFido2Swift",
             linkerSettings: [
-                .linkedFramework("libCbor"),
-                .linkedFramework("libCrypto"),
+                .linkedFramework("LibCbor"),
+                .linkedFramework("LibCrypto"),
                 .linkedFramework("libfido2"),
             ]
         ),
-        .binaryTarget(name: "libCbor", path: "./Frameworks/libCbor.xcframework"),
-        .binaryTarget(name: "libCrypto", path: "./Frameworks/libCrypto.xcframework"),
+        .binaryTarget(name: "LibCbor", path: "./Frameworks/libCbor.xcframework"),
+        .binaryTarget(name: "LibCrypto", path: "./Frameworks/libCrypto.xcframework"),
         .binaryTarget(name: "libfido2", path: "./Frameworks/libfido2.xcframework"),
     ]
 )


### PR DESCRIPTION
### ⛔️Don't merge this yet. I don't know it actually solved my problem.⛔️

I'm having serious issues linking this package to another Swift Package which doesn't make sense to me.

Part 1 of implementing Implement Security Key Auth into xcodes CLI tool.

Reference: https://github.com/XcodesOrg/XcodesApp/pull/617 

Since the CLI tool is a swift package and not an Xcode project we need to Explicitly link these binary dependencies to your library. This allows the linker down stream to work correctly.

Let me know if you have any questions. Also if this is going to be a "true" dependency it would be great to get releases setup on GitHub so we don't reference commit hashes.