### PR TITLE
Allow consumers to check if device is attached

### DIFF
--- a/LibFido2Swift/Sources/LibFido2Swift/LibFido2Swift.swift
+++ b/LibFido2Swift/Sources/LibFido2Swift/LibFido2Swift.swift
@@ -66,6 +66,15 @@ public class FIDO2 {
     
     public init() {}
     
+    public func hasDeviceAttached() -> Bool {
+        do {
+            let _ = try findFirstDevicePath()
+            return true
+        } catch {
+            return false
+        }
+    }
+    
     public func deviceHasPin() throws -> Bool {
         let devPath = try findFirstDevicePath()
         

--- a/LibFido2TestApp/ContentView.swift
+++ b/LibFido2TestApp/ContentView.swift
@@ -16,6 +16,8 @@ struct ContentView: View {
     @AppStorage("origin") var origin = ""
     @AppStorage("devicePin") var devicePin = ""
     @State var responseJson = ""
+    @State private var isDevicePresent = false
+    @State private var isDevicePresentAlertShown = false
     var body: some View {
         VStack {
             VStack {
@@ -32,6 +34,17 @@ struct ContentView: View {
                             print(error)
                         }
                     }
+                }
+                Button("Is Device Present?") {
+                    isDevicePresent = fido2.hasDeviceAttached()
+                    isDevicePresentAlertShown = true
+                }
+                .alert(isPresented: $isDevicePresentAlertShown) {
+                    Alert(
+                        title: Text("Device is \(isDevicePresent ? "present" : "not present")"),
+                        message: nil,
+                        dismissButton: .default(Text("OK"))
+                    )
                 }
                 Button("Cancel") {
                     fido2.cancel()


### PR DESCRIPTION
This PR exposes the ability to check if a FIDO2 device is attached.

Whilst adding PIN-less support to the Xcodes app, it had become evident that in order to support a nice UX around the PIN-less assertation we need a way to know if a device is present.
It is possible to kind of achieve this with the current API that the library has but it does put the onus of dealing with errors on the consumer of the API. This change should hopefully make that much simpler for upstream projects.

I've also added a little UI into the dev app to check this functionality.
![General UI](https://github.com/user-attachments/assets/089540e6-1bdd-43fa-b69a-f347db8b4448)

<img width="1012" alt="alert" src="https://github.com/user-attachments/assets/ede7e648-9b46-4bda-b66f-fad82bad573f">
